### PR TITLE
Add dark mode styling

### DIFF
--- a/docs/src/custom.css
+++ b/docs/src/custom.css
@@ -17,12 +17,22 @@ pre {
     overflow-x: auto;
 }
 
+.ayu pre, .navy pre, .coal pre {
+    color: var(--inline-code-color-dark);
+	background-color: var(--inline-code-bg-dark)
+}
+
 /* Inline code styling */
 code {
     background: #f3f4f6;
     padding: 2px 4px;
     border-radius: 3px;
     font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace;
+}
+
+.ayu code, .navy code, .coal code {
+    color: var(--inline-code-color-dark);
+	background-color: var(--inline-code-bg-dark)
 }
 
 /* Mathematical notation improvements */


### PR DESCRIPTION
Add styling to make code display correctly in dark mode.

Example from [The Lambda Calculus](<https://sdiehl.github.io/typechecker-zoo/algorithm-w/lambda-calculus.html#the-lambda-calculus>) using the Ayu color scheme:

Before:
<img width="589" height="293" alt="{A6A4A90D-199D-47EF-91B2-A35DFB13B20B}" src="https://github.com/user-attachments/assets/14888f71-ecf0-4e83-ab31-2771f6cd8110" />

After:
<img width="585" height="294" alt="{81FADA45-CDDB-41B1-91F3-CCD83D958078}" src="https://github.com/user-attachments/assets/a5b7016f-412f-41cc-bf29-e017f82284ea" />
